### PR TITLE
修复缩略图拖拽至画布出现文本元素

### DIFF
--- a/src/views/Editor/Canvas/hooks/useDropImageOrText.ts
+++ b/src/views/Editor/Canvas/hooks/useDropImageOrText.ts
@@ -12,7 +12,7 @@ export default (elementRef: Ref<HTMLElement | undefined>) => {
 
   // 拖拽元素到画布中
   const handleDrop = (e: DragEvent) => {
-    if (!e.dataTransfer) return
+    if (!e.dataTransfer || e.dataTransfer.items.length === 0) return
     const dataTransferItem = e.dataTransfer.items[0]
 
     // 检查事件对象中是否存在图片，存在则插入图片，否则继续检查是否存在文字，存在则插入文字

--- a/src/views/Editor/Thumbnails/index.vue
+++ b/src/views/Editor/Thumbnails/index.vue
@@ -12,6 +12,7 @@
       :animation="300"
       :scroll="true"
       :scrollSensitivity="50"
+      :setData="null"
       @end="handleDragEnd"
       itemKey="id"
     >


### PR DESCRIPTION
1. 不使用VueDraggable拖拽自带的dataTransfer设置: `dataTransfer.setData('Text', dragEl.textContent)`
2. 判断dataTransfer.items可能为空的情况