### PR TITLE
fix: 修复添加元素后无法直接ctrl+z 撤销

### DIFF
--- a/src/hooks/useCreateElement.ts
+++ b/src/hooks/useCreateElement.ts
@@ -38,7 +38,9 @@ export default () => {
     store.commit(MutationTypes.SET_ACTIVE_ELEMENT_ID_LIST, [element.id])
 
     if (creatingElement.value) store.commit(MutationTypes.SET_CREATING_ELEMENT, null)
-
+    setTimeout(() => {
+      store.commit(MutationTypes.SET_EDITORAREA_FOCUS, true)
+    }, 0)
     addHistorySnapshot()
   }
 


### PR DESCRIPTION
因为添加表格和图表不会点击画布   
取消焦点的顺序问题editorAreaFocus false导致快捷键不触发
所以添加了setTimeout让滞后执行