### PR TITLE
fix: 修复themeColor大于10时，浏览器崩溃问题

### DIFF
--- a/src/views/components/element/ChartElement/Chart.vue
+++ b/src/views/components/element/ChartElement/Chart.vue
@@ -129,7 +129,7 @@ export default defineComponent({
 
     const themeColors = computed(() => {
       let colors: string[] = []
-      if (props.themeColor.length === 10) colors = props.themeColor
+      if (props.themeColor.length >= 10) colors = props.themeColor
       else if (props.themeColor.length === 1) colors = tinycolor(props.themeColor[0]).analogous(10).map(color => color.toHexString())
       else {
         const len = props.themeColor.length


### PR DESCRIPTION
当`themeColor`长度大于10，执行`tinycolor.analogous()`方法时，参数为负数，导致`analogous`死循环