### PR TITLE
fix: detect immediately full screen is not work after entering full screen #106

### DIFF
--- a/src/hooks/useScreening.ts
+++ b/src/hooks/useScreening.ts
@@ -8,7 +8,9 @@ export default () => {
   // 进入放映状态（从当前页开始）
   const enterScreening = () => {
     enterFullscreen()
-    screenStore.setScreening(true)
+    setTimeout(() => {
+      screenStore.setScreening(true)
+    }, 200)
   }
 
   // 进入放映状态（从第一页开始）


### PR DESCRIPTION
is `useFullscreen.ts` file
```js
  const windowResizeListener = () => {
    // fullscreenState.value is undefined and emit exitScreening in safari
    fullscreenState.value = isFullscreen()
    if (!fullscreenState.value && escExit.value) exitScreening()

    escExit.value = true
  }
```

<img width="343" alt="Screen Shot 2022-05-24 at 14 14 25" src="https://user-images.githubusercontent.com/16227832/169966741-bc1f2438-4b37-49ae-985d-74f3ba55671a.png">
