### PR TITLE
fix: 修改复制页面时若element存在link检查并替换

### DIFF
--- a/src/hooks/useAddSlidesOrElements.ts
+++ b/src/hooks/useAddSlidesOrElements.ts
@@ -2,7 +2,7 @@ import { storeToRefs } from 'pinia'
 import { nanoid } from 'nanoid'
 import { useSlidesStore, useMainStore } from '@/store'
 import { PPTElement, Slide } from '@/types/slides'
-import { createElementIdMap } from '@/utils/element'
+import { createSlideIdMap, createElementIdMap } from '@/utils/element'
 import useHistorySnapshot from '@/hooks/useHistorySnapshot'
 
 export default () => {
@@ -42,12 +42,23 @@ export default () => {
    * @param slide 页面数据
    */
   const addSlidesFromData = (slides: Slide[]) => {
+    const slideIdMap = createSlideIdMap(slides)
     const newSlides = slides.map(slide => {
       const { groupIdMap, elIdMap } = createElementIdMap(slide.elements)
 
       for (const element of slide.elements) {
         element.id = elIdMap[element.id]
         if (element.groupId) element.groupId = groupIdMap[element.groupId]
+		
+        // 判断element跳转链接,如为slide且复制页面含target则替换,否则重置为undefined
+        if (element?.link && element.link.type === 'slide') {
+          if (slideIdMap[element.link.target]) {
+            element.link.target = slideIdMap[element.link.target]
+          }
+          else {
+            element.link = undefined
+          }
+        }
       }
       // 动画id替换
       if (slide.animations) {

--- a/src/utils/element.ts
+++ b/src/utils/element.ts
@@ -153,6 +153,19 @@ export const uniqAlignLines = (lines: AlignLine[]) => {
 }
 
 /**
+ * 以页面列表为基础，为每一个页面生成新的ID，并关联到旧ID形成一个字典
+ * 主要用于页面元素时，维持数据中各处页面ID原有的关系
+ * @param slides 页面列表
+ */
+export const createSlideIdMap = (slides: Slide[]) => {
+  const slideIdMap = {}
+  for (const slide of slides) {
+    slideIdMap[slide.id] = nanoid(10)
+  }
+  return slideIdMap
+}
+
+/**
    * 以元素列表为基础，为每一个元素生成新的ID，并关联到旧ID形成一个字典
    * 主要用于复制元素时，维持数据中各处元素ID原有的关系
    * 例如：原本两个组合的元素拥有相同的groupId，复制后依然会拥有另一个相同的groupId


### PR DESCRIPTION
若element存在link且type === 'slide'则替换对应跳转slide否则重置link