### PR TITLE
fix: text 文本框宽度异常导致旋转异常

### DIFF
--- a/src/views/components/element/TextElement/index.vue
+++ b/src/views/components/element/TextElement/index.vue
@@ -5,7 +5,7 @@
     :style="{
       top: elementInfo.top + 'px',
       left: elementInfo.left + 'px',
-      width: elementInfo.vertical ? 'auto' : elementInfo.width + 'px',
+      width: elementInfo.width + 'px',
       height: elementInfo.vertical ? elementInfo.height + 'px' : 'auto',
     }"
   >


### PR DESCRIPTION
问题描述：
竖直文本框的文本内容为多行时，旋转效果异常
产生原因：
元素（类名） rotate-wrapper 和元素（类名）  element-content 宽度不一致，但是在控制台重新刷新一下宽度又好了，具体为什么父子元素高度不一致原因未知（难道是 writing-mode 这个属性导致的？）
解决方法：
这个 PR 直接为父元素绑定了高度，避免了问题的发生
相关 issues: #143 