### PR TITLE
video和audio添加throttle

### DIFF
--- a/src/views/components/element/AudioElement/AudioPlayer.vue
+++ b/src/views/components/element/AudioElement/AudioPlayer.vue
@@ -74,6 +74,7 @@
 
 <script lang="ts" setup>
 import { computed, ref } from 'vue'
+import { throttle } from 'lodash'
 import { message } from 'ant-design-vue'
 
 const props = defineProps({
@@ -153,10 +154,10 @@ const pause = () => {
   audioRef.value.pause()
 }
 
-const toggle = () => {
+const toggle = throttle(function() {
   if (paused.value) play() 
   else pause()
-}
+}, 1000, { trailing: true })
 
 const setVolume = (percentage: number) => {
   if (!audioRef.value) return

--- a/src/views/components/element/VideoElement/VideoPlayer/index.vue
+++ b/src/views/components/element/VideoElement/VideoPlayer/index.vue
@@ -117,6 +117,7 @@
 <script lang="ts" setup>
 import { computed, ref } from 'vue'
 import useMSE from './useMSE'
+import { throttle } from 'lodash'
 
 const props = defineProps({
   width: {
@@ -214,10 +215,10 @@ const pause = () => {
   bezelTransition.value = true
 }
 
-const toggle = () => {
+const toggle = throttle(function() {
   if (paused.value) play() 
   else pause()
-}
+}, 1000, { trailing: true })
 
 const setVolume = (percentage: number) => {
   if (!videoRef.value) return


### PR DESCRIPTION
问题：在谷歌中快速点击暂停播放会出现Uncaught (in promise) DOMException: The play() request was interrupted by a call to pause(). 因此添加throttle