### PR TITLE
fix: 修复因样式导致崩溃问题

### DIFF
--- a/src/components/ColorPicker/index.vue
+++ b/src/components/ColorPicker/index.vue
@@ -408,8 +408,7 @@ const customEyeDropper = () => {
 .picker-presets-color {
   @include flex-grid-layout-children(10, 7%);
 
-  height: 0;
-  padding-bottom: 7%;
+  height: 16px;
   flex-shrink: 0;
   position: relative;
   cursor: pointer;


### PR DESCRIPTION
在 chrome 版本 107.0.5304.88（正式版本） （32 位）下padding-bottom为百分比时，宽高2400*1300会导致浏览器崩溃