### PR TITLE
fix: 左侧缩略图拖拽后无法删除

### DIFF
--- a/src/components/Sortable.vue
+++ b/src/components/Sortable.vue
@@ -1,13 +1,9 @@
 <template>
-  <div ref="containerRef" :class="$props.class">
-    <slot 
-      v-for="(item, index) in list" 
-      :key="item[props.itemKey]" 
-      :element="item" 
-      :index="index" 
-      name="item"
-    ></slot>
-  </div>
+  <ol ref="containerRef" :class="$props.class">
+    <li v-for="(item, index) in list" :key="item[props.itemKey]">
+      <slot :element="item" :index="index" name="item"></slot>
+    </li>
+  </ol>
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
修复缺陷【左侧缩略图拖拽后无法删除  #189】
 补充描述：
经过多次测试，缺陷规律复现如下：
1. 向下拖拽任意一个 slide 缩略图（除最后一个），只移动一个单位，或移动一个单位再回到原位置。
2. 删除拖拽的元素
3. 会发现删除不掉

事实上，pinia 中的 slides 已经被修改，只是页面没有做出相应的更新。

经过验证，很大程度上能确认是 sortablejs 与 vue v-for 机制导致的问题。
我认为这可能是由于 sortablejs 库在移动元素时，直接修改了 DOM 节点的位置，而不是通过修改数据来更新视图。因此，Vue 的响应式系统无法检测到数据的变化，也就无法更新视图了。（更新 slides 也没用）。

目前我的解决方法是在 slot 插槽外面再加一层，同时修改了一下 html 语义化。

如果 PR 不能被采纳，我也希望以下几点能起到帮助性作用：
1. 起初我以为是 slot 上绑定 v-for 出现的 bug，但我后面使用 vue 去实操过了，vue 没有问题 [vue 演练场](https://sfc.vuejs.org/#eNrFVE1v2zAM/Sucd4iNOXbTDhhgOEGKnbbDNmDHuhjSmEm12JImyemCwP99lPwROwGC7jDMCGKLj3x8oigevXspo32FXuKleq2YNKDRVHKRcVZKoQwcQeEGatgoUcKEXCc99FGUsrVHsV1YJoIzvhZcGygY/c1tvP+QcYAjyxOYzCYh7FdFhQnM3FOHJ/D2BN66ZwjencA791jwMSCHLmMlKZ/P8gDmCzjayMYuivwTz/E3oVZU5FiiDeON2feZwdIF2Y+I5TCfz4F4LAXbgN8TLOAmaJghMw35j3afn79//RLJldLou09tFONbtjn4p5yBY8yMi4m0LNgae/IQZtdgmMIshJtwsIWHDnsMqAakaYCRIkdj7XXG6dfIzcUL/9dVSocEBfKtef5vVXt3rWqvLhoW5zUbBY3qVRhUrlbDUr3pSkWcadzcNbpltCAHWawM0gogdZcqsXzzzHNSPAcQ1DnCW0tK8NGxh0AnRBute0/yzdm+X9D9OToZTmBNAjp7+lQZIzgs11SzHTFW0gknwQGxVTKNG48B10WMbahhlF2/Kg6LURgWaPAiMI1PW0njca3c0KHPkd0LvWY+TcuVjH5qwWm4uRPLWkBnXtJ2I9loZtl15j0bI3USxxWXu220FmW8JCxWFTesxGkuyuVddBu9/0CKtBnaI9Tl9EmJF42KMmaeG1oteUzGPaqpQjolhepqsjPfUcIz7CJp17NUgG4Y/91Yb1pdKiE1tXSOdPPxm135fcP3dTMHSWP4XqnVod2swl8VU0iD2qgKndHO55pa/lq/D05XF8K0YwxgP90IRV3iWqRt8YBeTkbm9X7JDg/k1jbSEGgviX2NzJbJ2u17APBVib17Y1yQcNLUNptVOm42r/4D9LxhnQ==)
2. 使用 vueTools 直接修改响应式数据 slides，页面如期望变化，也确定了不是没有触发响应性引起的