### PR TITLE
fix: 图表主题颜色调节透明度无效

### DIFF
--- a/src/views/components/element/ChartElement/Chart.vue
+++ b/src/views/components/element/ChartElement/Chart.vue
@@ -124,10 +124,10 @@ onMounted(renderChart)
 const themeColors = computed(() => {
   let colors: string[] = []
   if (props.themeColor.length >= 10) colors = props.themeColor
-  else if (props.themeColor.length === 1) colors = tinycolor(props.themeColor[0]).analogous(10).map(color => color.toHexString())
+  else if (props.themeColor.length === 1) colors = tinycolor(props.themeColor[0]).analogous(10).map(color => color.toRgbString())
   else {
     const len = props.themeColor.length
-    const supplement = tinycolor(props.themeColor[len - 1]).analogous(10 + 1 - len).map(color => color.toHexString())
+    const supplement = tinycolor(props.themeColor[len - 1]).analogous(10 + 1 - len).map(color => color.toRgbString())
     colors = [...props.themeColor.slice(0, len - 1), ...supplement]
   }
   return colors


### PR DESCRIPTION
背景：发现图表主题颜色调节透明度无效

修改分析：
  toHexString 方法不支持 alpha 通道，
  toHex8String 方法支持 alpha 通道，但 props.themeColor 是 rgba(r,g,b,a) 的形式，
  toRgbString 方法不仅可以修复调节透明度无效，还保证了数据格式的一致性。
  