### PR TITLE
fix: 图表切换后，选项状态显示错误

### DIFF
--- a/src/hooks/useCreateElement.ts
+++ b/src/hooks/useCreateElement.ts
@@ -103,11 +103,15 @@ export default () => {
       },
     }
 
-    let options: ChartOptions = {}
-    if (type === 'horizontalBar') options = { horizontalBars: true }
-    else if (type === 'area') options = { showArea: true }
-    else if (type === 'scatter') options = { showLine: false }
-    else if (type === 'ring') options = { donut: true }
+    const options: ChartOptions = {
+      ...(type === 'bar' ? { horizontalBars: false, stackBars: false } : {}),
+      ...(type === 'horizontalBar' ? { horizontalBars: true, stackBars: false } : {}),
+      ...(type === 'line' ? { showLine: true, lineSmooth: true, showArea: false } : {}),
+      ...(type === 'area' ? { showLine: true, lineSmooth: true, showArea: true } : {}),
+      ...(type === 'scatter' ? { showLine: false, lineSmooth: true, showArea: false } : {}),
+      ...(type === 'pie' ? { donut: false } : {}),
+      ...(type === 'ring' ? { donut: true } : {}),
+    }
 
     createElement({
       ...newElement,

--- a/src/views/Editor/Toolbar/ElementStylePanel/ChartStylePanel/index.vue
+++ b/src/views/Editor/Toolbar/ElementStylePanel/ChartStylePanel/index.vue
@@ -230,12 +230,12 @@ watch(handleElement, () => {
       stackBars: _stackBars,
     } = handleElement.value.options
 
-    if (_lineSmooth !== undefined) lineSmooth.value = _lineSmooth as boolean
-    if (_showLine !== undefined) showLine.value = _showLine
-    if (_showArea !== undefined) showArea.value = _showArea
-    if (_horizontalBars !== undefined) horizontalBars.value = _horizontalBars
-    if (_donut !== undefined) donut.value = _donut
-    if (_stackBars !== undefined) stackBars.value = _stackBars
+    lineSmooth.value = !!_lineSmooth
+    showLine.value = !!_showLine
+    showArea.value = !!_showArea
+    horizontalBars.value = !!_horizontalBars
+    donut.value = !!_donut
+    stackBars.value = !!_stackBars
   }
 
   themeColor.value = handleElement.value.themeColor


### PR DESCRIPTION
缺陷背景：
UI 层，支持创建这六种图表：`柱状图`, `条形图`, `折线图`, `面积图`, `散点图`, `饼图`, `环形图`
![image](https://user-images.githubusercontent.com/74353117/231093389-986285e5-ad07-40fe-a5b6-c829c511799b.png)

代码逻辑中，只有三种图表类型：`bar`, `line`, `pie`

之所以会有六种图表，是通过图表 Options 的不同，在这三种图表类型基础之上，衍生出了其它这几种图表
ChartOptions：`horizontalBars`, `stackBars`, `showLine`, `lineSmooth`, `showArea`, `donut`

映射关系：
`bar` 
-> `horizontalBars` // 是否条形图
-> `stackBars`         // 是否堆叠模式

`line`
-> `showLine`      // 是否显示线条
-> `showArea`     // 是否显示面积
-> `lineSmooth`  // 是否线条平滑

`pie` 
-> `donut`      // 是否环形

**缺陷原因：**

创建 ChartElement 时，只给了 ChartOptions 部分的初始值，导致右侧 ChartStylePanel 组件中对状态的初始值判断不准确。详见代码的新旧处理方式即可看出。

修改方法：
上面特意列出了图表的对应关系，在创建时，把映射的属性附上初始值，在对应的 ChartStylePanel 组件中通过对 `boolean` 类型的判断即可准确的显示状态。对于非映射属性，依旧不会赋值显示在对象上。

相关 issues: #196 

望采纳~