### PR TITLE
新增搜索替换功能

### DIFF
--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -1,0 +1,426 @@
+import { useSlidesStore, useMainStore } from '@/store'
+import { SearchAction } from '@/types/toolbar'
+
+export default () => {
+  const {searchObj} = useMainStore()
+  const slidesStore = useSlidesStore()
+
+  /**
+   * dom节点中的文本列表
+   * @param el 
+   * @param lines 
+   */
+  const textsInElement = (el: HTMLElement, lines: string[]) => {
+    for (let i = 0; i < el.childNodes.length; i++) {
+      const child: any = el.childNodes[i]
+      if (child.nodeName === '#text') {
+        lines.push(child)
+      }
+      else if (child.childNodes.length === 1 && child.children.length === 0) {
+        lines.push(child.innerText)
+      }
+      else {
+        textsInElement(child, lines)
+      }
+    }
+  }
+
+  /**
+   * 搜索element中内容出现次数
+   * @param source 
+   * @param element 
+   * @returns count:number
+   */
+  const countInElement = (source: string, element: any) => {
+    let count = 0
+    if ((element.type === 'text' || element.type === 'shape') && (element?.content || element?.text?.content)) {
+      const divEl = document.createElement('div')
+      /* bca-disable */
+      divEl.innerHTML = element?.content || element?.text?.content || ''
+      const textLines: string[] = []
+      textsInElement(divEl, textLines)
+      textLines.forEach((txt) => {
+        count += (txt.match(new RegExp(source, 'g')) || []).length
+      })
+    }
+    return count
+  }
+  
+  /**
+   * 搜索slide[]中内容出现次数
+   * @param source 
+   * @param slides 
+   * @returns count:出现次数，firstSlideIndex:第一次出现的slide
+   */
+  const countInSlides = (source: string, slides: any[]) => {
+    let count = 0
+    let firstSlideIndex = -1
+    let firstElementIndex = 0
+    for (let i = 0; i < slides.length; i++) {
+      const elements = slides[i].elements
+      for (let j = 0; j < elements.length; j++) {
+        count += countInElement(source, elements[j])
+        if (firstSlideIndex === -1 && count > 0) {
+          firstSlideIndex = i
+          firstElementIndex = j
+        }
+      }
+    }
+    return {
+      count,
+      firstSlideIndex,
+      firstElementIndex,
+    }
+  }
+
+  /**
+   * 高亮
+   * @param source 
+   * @param el 
+   * @param index 
+   * @param ref: {counting: number, isEnd: boolean}
+   */
+  const highlight = (source: string, el: HTMLElement, index: number, ref: any = {counting: 0, isEnd: false}) => {
+    for (let i = 0; i < el.childNodes.length; i++) {
+      const child: any = el.childNodes[i]
+      const target = '<span style="background-color: #ffc12a;">' + source + '</span>'
+      if (child.nodeName === '#text' || (child.childNodes.length === 1 && child.children.length === 0)) {
+        const txtCount = (child.textContent?.match(new RegExp(source, 'g')) || []).length
+        ref.counting += txtCount
+        if (ref.counting > index) {
+          const repIndex = index - (ref.counting - txtCount)
+          const reg = new RegExp('((?:.*?' + source + '.*?){' + repIndex + '}.*?)' + source, 'm')
+          if (child.nodeName === '#text') {
+            el.innerHTML = el.innerHTML?.replace(reg, '$1' + target) || ''
+          }
+          else {
+            child.innerHTML = child.innerHTML?.replace(reg, '$1' + target) || null
+          }
+          ref.isEnd = true
+          break
+        }
+      }
+      else {
+        highlight(source, child as HTMLElement, index, ref)
+        if (ref.isEnd) {
+          break
+        }
+      }
+    }
+  }
+
+  /**
+   * 取消高亮
+   * @param source 
+   * @param el 
+   */
+  const clearHighlight = () => {
+    const element: any = slidesStore.slides[searchObj.slideIndex]?.elements[searchObj.elementIndex]
+    if (element) {
+      const htmlEl = document.getElementById('editable-element-' + element.id)?.querySelector('.ProseMirror') as HTMLElement
+      const target = '<span style="background-color: #ffc12a;">' + searchObj.oldSearchText + '</span>'
+      if (htmlEl) {
+        htmlEl.innerHTML = htmlEl.innerHTML?.replace(target, searchObj.oldSearchText)
+      }
+    }
+  }
+
+  /**
+   * 搜索
+   * @param action:SearchActionType
+   * @param startSlideIndex 指定开始slide（4replace)
+   */
+  const search = (action: SearchAction = SearchAction.All, startSlideIndex = 0) => {
+    const slides = slidesStore.slides
+    let slideIndex = -1
+    let hasFind = false
+    const {oldSearchText, searchText, searchIndex, searchCount, subIndexInSlide, subIndexInElement} = searchObj
+
+    if (!searchObj.searchText) {
+      searchObj.searchCount = 0
+      searchObj.searchIndex = 0
+      return
+    }
+    if ((action === SearchAction.Next && searchIndex === searchCount)
+      || (action === SearchAction.Prev && searchIndex === 1)
+    ) {
+      return
+    }
+
+    if (action === SearchAction.All && oldSearchText === searchText && searchIndex > 0 && searchIndex < searchCount) {
+      action = SearchAction.Next
+    }
+
+    clearHighlight()
+    if (action === SearchAction.All) {
+      searchObj.oldSearchText = searchText
+    }
+
+    // search all
+    if (action === SearchAction.All) {
+      const {count, firstSlideIndex, firstElementIndex} = countInSlides(searchText, slides)
+      slideIndex = firstSlideIndex
+      searchObj.elementIndex = firstElementIndex
+      searchObj.searchCount = count
+      searchObj.searchIndex = count > 0 ? 1 : 0
+      searchObj.subIndexInSlide = 0
+      searchObj.subIndexInElement = 0
+      hasFind = count > 0
+    }
+
+    // search from current slide
+    const newSearch = searchObj.slideIndex !== slidesStore.slideIndex
+    if (action !== SearchAction.All && newSearch) {
+      searchObj.subIndexInSlide = 0
+    }
+
+    // search next
+    if (action === SearchAction.Next) {
+      for (let i = startSlideIndex || slidesStore.slideIndex; i < slides.length; i++) {
+        slideIndex = i
+        let slideTextCounting = 0 // 当前slide中动态匹配到的个数
+        const elements = slides[i].elements
+        for (let j = 0; j < elements.length; j++) {
+          const matchCount = countInElement(searchText, elements[j])
+          if (matchCount) {
+            slideTextCounting += matchCount
+            if (newSearch) {
+              searchObj.subIndexInSlide = 0
+              searchObj.subIndexInElement = 0
+              const {count} = countInSlides(searchText, slides.slice(0, slidesStore.slideIndex))
+              searchObj.searchIndex = count + 1
+              searchObj.elementIndex = j
+              hasFind = true
+              break
+            }
+            else {
+              if (slideIndex !== slidesStore.slideIndex) {
+                // other slide
+                searchObj.subIndexInSlide = 0
+                searchObj.subIndexInElement = 0
+                searchObj.searchIndex++
+                hasFind = true
+                searchObj.elementIndex = j
+                break
+              }
+              if (searchObj.subIndexInSlide + 2 <= slideTextCounting) {
+                // current slide
+                searchObj.subIndexInSlide++
+                searchObj.subIndexInElement = searchObj.elementIndex !== j || subIndexInElement >= matchCount - 1 
+                  ? 0
+                  : searchObj.subIndexInElement + 1
+                searchObj.searchIndex++
+                searchObj.elementIndex = j
+                hasFind = true
+                break
+              }
+            }
+          }
+        }
+        if (hasFind) {
+          break
+        }
+      }
+    }
+
+    // search prev
+    if (action === SearchAction.Prev) {
+      for (let i = slidesStore.slideIndex; i >= 0; i--) {
+        slideIndex = i
+        let slideTextCounting = 0 // 当前slide中动态匹配到的个数
+        const elements = slides[i].elements
+        for (let j = elements.length - 1; j >= 0; j--) {
+          const matchCount = countInElement(searchText, elements[j])
+          if (matchCount) {
+            slideTextCounting += matchCount
+            const {count: slideTextCount} = countInSlides(searchText, [slides[slideIndex]])
+            if (newSearch) {
+              searchObj.subIndexInSlide = slideTextCount - 1
+              searchObj.subIndexInElement = matchCount - 1
+              const {count} = countInSlides(searchText, slides.slice(0, slideIndex + 1))
+              searchObj.searchIndex = count
+              searchObj.elementIndex = j
+              hasFind = true
+              break
+            }
+            else {
+              if (slideIndex !== slidesStore.slideIndex) {
+                // new slide
+                searchObj.subIndexInSlide = slideTextCount - 1
+                searchObj.subIndexInElement = matchCount - 1
+                searchObj.searchIndex--
+                searchObj.elementIndex = j
+                hasFind = true
+                break
+              }
+              if (searchObj.subIndexInSlide - 1 >= 0 && (
+                matchCount > 1 
+                  ? searchObj.subIndexInElement !== 0
+                  : subIndexInSlide > slideTextCount - slideTextCounting
+              )) {
+                // current slide
+                searchObj.subIndexInSlide--
+                searchObj.subIndexInElement = subIndexInElement > 0
+                  ? searchObj.subIndexInElement - 1
+                  : matchCount - 1
+                searchObj.searchIndex--
+                searchObj.elementIndex = j
+                hasFind = true
+                break
+              }
+            }
+          }
+        }
+        if (hasFind) {
+          break
+        }
+      }
+    }
+    
+    if (hasFind) {
+      searchObj.slideIndex = slideIndex
+      slidesStore.updateSlideIndex(slideIndex)
+      // hightlight
+      setTimeout(() => {
+        const element: any = slidesStore.slides[searchObj.slideIndex].elements[searchObj.elementIndex]
+        const htmlEl = document.getElementById('editable-element-' + element.id)?.querySelector('.ProseMirror') as HTMLElement
+        htmlEl && highlight(searchObj.searchText, htmlEl, searchObj.subIndexInElement)
+      }, 0)
+    }
+  }
+
+  /**
+   * 替换element中的内容
+   * @param source 
+   * @param target 
+   * @param el 
+   * @param count 动态计数
+   * @param index 替换第几个，-1表示替换全部
+   */
+  const replaceInElement = (source: string, target: string, el: HTMLElement, index: number, count = 0) => {
+    const {childNodes} = el
+    for (let i = 0; i < childNodes.length; i++) {
+      const child = childNodes[i]
+      if (child.nodeName === '#text') {
+        // TODO child.textContent = 'undefined'
+        if (index < 0) {
+          child.textContent = child.textContent?.replaceAll(source, target) || null
+          break
+        }
+
+        const txtCount = (child.textContent?.match(new RegExp(source, 'g')) || []).length
+        count += txtCount
+        if (count > index) {
+          const repIndex = index - (count - txtCount)
+          child.textContent = child.textContent?.replace(new RegExp('((?:.*?' + source + '.*?){' + repIndex + '}.*?)' + source, 'm'), '$1' + target) || null
+          break
+        }
+      }
+      else {
+        replaceInElement(source, target, child as HTMLElement, index, count)
+      }
+    }
+  }
+
+  /**
+   * 替换
+   * @returns 
+   */
+  const replace = () => {
+    const {searchText, replaceText, searchCount, slideIndex, elementIndex, subIndexInSlide, subIndexInElement} = searchObj
+    if (searchCount <= 0) {
+      return
+    }
+
+    clearHighlight()
+    
+    // replace text in element
+    const element: any = slidesStore.slides[slideIndex].elements[elementIndex]
+    const divEl = document.createElement('div')
+    /* bca-disable */
+    divEl.innerHTML = element?.content || element?.text?.content
+    replaceInElement(searchText, replaceText, divEl, subIndexInElement)
+    if (element.content) {
+      element.content = divEl.innerHTML
+    }
+    if (element.text && element.text.content) {
+      element.text.content = divEl.innerHTML
+    }
+
+    // update searchObj for search next
+    const { count: slideTextCount } = countInSlides(searchText, [slidesStore.slides[slideIndex]])
+    if (slideTextCount > subIndexInSlide) {
+      searchObj.subIndexInSlide--
+      if (searchObj.subIndexInElement > 0) {
+        const currElementTextCount = countInElement(searchText, element)
+        if (currElementTextCount - 1 >= searchObj.subIndexInElement) {
+          searchObj.subIndexInElement--
+        }
+        else {
+          searchObj.subIndexInElement = 0
+        }
+      }
+    }
+    else {
+      searchObj.slideIndex++
+      searchObj.subIndexInSlide = 0
+      searchObj.elementIndex = 0
+      searchObj.subIndexInElement = 0
+    }
+    searchObj.searchCount--
+    searchObj.searchIndex-- // 自动搜索下一个会矫正
+    search(SearchAction.Next, searchObj.slideIndex)
+  }
+
+  /**
+   * 替换全部
+   * @returns 
+   */
+  const replaceAll = () => {
+    if (searchObj.searchCount <= 0) {
+      return
+    }
+
+    const slides = slidesStore.slides
+    const divEl = document.createElement('div')
+    for (let i = 0; i < slides.length; i++) {
+      const elements = slides[i].elements
+      for (let j = 0; j < elements.length; j++) {
+        const element: any = elements[j]
+        divEl.innerHTML = element?.content || element?.text?.content
+        replaceInElement(searchObj.searchText, searchObj.replaceText, divEl, -1)
+        if (element.content) {
+          element.content = divEl.innerHTML
+        }
+        if (element.text && element.text.content) {
+          element.text.content = divEl.innerHTML
+        }
+      }
+    }
+
+    searchObj.searchCount = 0
+    searchObj.searchIndex = 0
+  }
+
+  /**
+   * 取消搜索
+   */
+  const cancelSearch = () => {
+    clearHighlight()
+    searchObj.searchText = ''
+    searchObj.replaceText = ''
+    searchObj.searchIndex = 0
+    searchObj.searchCount = 0
+    searchObj.slideIndex = 0
+    searchObj.elementIndex = 0
+    searchObj.subIndexInSlide = 0
+    searchObj.subIndexInElement = 0
+  }
+
+  return {
+    search,
+    replace,
+    replaceAll,
+    cancelSearch,
+  }
+}

--- a/src/plugins/icon.ts
+++ b/src/plugins/icon.ts
@@ -112,6 +112,10 @@ import {
   PreviewOpen,
   PreviewClose,
   StopwatchStart,
+  Search,
+  LeftOne,
+  RightOne,
+  AutoWidth,
 } from '@icon-park/vue-next'
 
 export const icons = {
@@ -225,6 +229,10 @@ export const icons = {
   IconPreviewOpen: PreviewOpen,
   IconPreviewClose: PreviewClose,
   IconStopwatchStart: StopwatchStart,
+  IconSearch: Search,
+  IconLeftOne: LeftOne,
+  IconRightOne: RightOne,
+  IconAutoWidth: AutoWidth,
 }
 
 export default {

--- a/src/store/main.ts
+++ b/src/store/main.ts
@@ -37,7 +37,7 @@ export interface MainState {
   searchObj: {
     oldSearchText: string,
     searchText: string
-    searchIndex: number
+    searchNum: number
     searchCount: number
     slideIndex: number
     elementIndex: number
@@ -79,7 +79,7 @@ export const useMainStore = defineStore('main', {
     searchObj: {
       oldSearchText: '',
       searchText: '',
-      searchIndex: 0,
+      searchNum: 0,
       searchCount: 0,
       slideIndex: 0,
       elementIndex: 0,

--- a/src/store/main.ts
+++ b/src/store/main.ts
@@ -34,6 +34,17 @@ export interface MainState {
   databaseId: string
   textFormatPainter: TextFormatPainter | null
   showSelectPanel: boolean
+  searchObj: {
+    oldSearchText: string,
+    searchText: string
+    searchIndex: number
+    searchCount: number
+    slideIndex: number
+    elementIndex: number
+    subIndexInSlide: number
+    subIndexInElement: number
+    replaceText: string
+  }
 }
 
 const nanoid = customAlphabet('0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz')
@@ -65,6 +76,17 @@ export const useMainStore = defineStore('main', {
     databaseId, // 标识当前应用的indexedDB数据库ID
     textFormatPainter: null, // 文字格式刷
     showSelectPanel: false, // 打开选择面板
+    searchObj: {
+      oldSearchText: '',
+      searchText: '',
+      searchIndex: 0,
+      searchCount: 0,
+      slideIndex: 0,
+      elementIndex: 0,
+      subIndexInSlide: 0,
+      subIndexInElement: 0,
+      replaceText: '',
+    },
   }),
 
   getters: {

--- a/src/types/toolbar.ts
+++ b/src/types/toolbar.ts
@@ -12,7 +12,9 @@ export const enum ToolbarStates {
  * 搜索操作
  */
 export const enum SearchAction {
+  Silent,
 	All,
 	Next,
 	Prev,
+  Replace,
 }

--- a/src/types/toolbar.ts
+++ b/src/types/toolbar.ts
@@ -7,3 +7,12 @@ export const enum ToolbarStates {
   SLIDE_ANIMATION = 'slideAnimation',
   MULTI_POSITION = 'multiPosition',
 }
+
+/**
+ * 搜索操作
+ */
+export const enum SearchAction {
+	All,
+	Next,
+	Prev,
+}

--- a/src/views/Editor/CanvasTool/SearchInput.vue
+++ b/src/views/Editor/CanvasTool/SearchInput.vue
@@ -1,0 +1,88 @@
+<template>
+  <div class="search-input">
+      <Input v-model:value="searchObj.searchText" placeholder="输入查找内容" @pressEnter="search()">
+        <template #prefix>
+          <IconSearch class="icon-item" />
+        </template>
+        <template #suffix>
+          <span class="num-tip">{{ searchObj.searchIndex }}/{{ searchObj.searchCount }}</span>
+          <span class="edge-line"></span>
+          <Tooltip title="上一个">
+              <IconLeftOne theme="filled" size="10"
+                :fill="searchObj.searchIndex > 1 ? '#333' : '#999'"
+                @click="prev()"
+              />
+          </Tooltip>
+          <Tooltip title="下一个">
+              <IconRightOne theme="filled" size="10"
+                :fill="searchObj.searchIndex < searchObj.searchCount ? '#333' : '#999'"
+                @click="next()"
+              />
+          </Tooltip>
+        </template>
+      </Input>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref } from 'vue'
+import { storeToRefs } from 'pinia'
+import { useMainStore } from '@/store'
+import useSearch from '@/hooks/useSearch'
+import { SearchAction } from '@/types/toolbar'
+import { Input, InputSearch, Tooltip } from 'ant-design-vue'
+
+export default defineComponent({
+  name: 'search-input',
+  emits: ['select'],
+  props: {
+    value: String,
+    width: Number,
+  },
+  components: {
+    Input,
+    // InputSearch,
+    Tooltip,
+  },
+  setup(props, { emit }) {
+    const { searchObj } = storeToRefs(useMainStore())
+    const { search } = useSearch()
+
+    const prev = () => {
+      search(SearchAction.Prev)
+    }
+    const next = () => {
+      search(SearchAction.Next)
+    }
+
+    return {
+      searchObj,
+      search,
+      prev,
+      next,
+    }
+  },
+})
+</script>
+
+<style lang="scss" scoped>
+.search-input {
+  box-sizing: border-box;
+  height: 32px;
+  display: flex;
+  flex-direction: column;
+  .num-tip {
+    color: #999;
+    font-size: 12px;
+  }
+  .edge-line {
+    width: 1px;
+    background: #eee;
+    height: 18px;
+    margin: 0 10px;
+  }
+  .i-icon-left-one {
+    margin-right: 8px;
+  }
+}
+</style>

--- a/src/views/Editor/CanvasTool/SearchInput.vue
+++ b/src/views/Editor/CanvasTool/SearchInput.vue
@@ -1,21 +1,21 @@
 <template>
   <div class="search-input">
-      <Input v-model:value="searchObj.searchText" placeholder="输入查找内容" @pressEnter="search()">
+      <Input v-model:value="searchObj.searchText" placeholder="输入查找内容" @change="silentSearch()" @pressEnter="search()">
         <template #prefix>
           <IconSearch class="icon-item" />
         </template>
         <template #suffix>
-          <span class="num-tip">{{ searchObj.searchIndex }}/{{ searchObj.searchCount }}</span>
+          <span class="num-tip">{{ searchObj.searchNum }}/{{ searchObj.searchCount }}</span>
           <span class="edge-line"></span>
           <Tooltip title="上一个">
               <IconLeftOne theme="filled" size="10"
-                :fill="searchObj.searchIndex > 1 ? '#333' : '#999'"
+                :fill="searchObj.searchCount > 0 ? '#333' : '#999'"
                 @click="prev()"
               />
           </Tooltip>
           <Tooltip title="下一个">
               <IconRightOne theme="filled" size="10"
-                :fill="searchObj.searchIndex < searchObj.searchCount ? '#333' : '#999'"
+                :fill="searchObj.searchCount > 0 ? '#333' : '#999'"
                 @click="next()"
               />
           </Tooltip>
@@ -48,6 +48,9 @@ export default defineComponent({
     const { searchObj } = storeToRefs(useMainStore())
     const { search } = useSearch()
 
+    const silentSearch = () => {
+      search(SearchAction.Silent)
+    }
     const prev = () => {
       search(SearchAction.Prev)
     }
@@ -57,6 +60,7 @@ export default defineComponent({
 
     return {
       searchObj,
+      silentSearch,
       search,
       prev,
       next,

--- a/src/views/Editor/CanvasTool/SearchPanel.vue
+++ b/src/views/Editor/CanvasTool/SearchPanel.vue
@@ -1,0 +1,165 @@
+<template>
+  <div class="search-panel">
+    <div class="tabs">
+      <div
+        class="tab"
+        v-for="item in tabList"
+        :key="item.key"
+        @click="selectedTabKey = item.key"
+      >
+        <p class="text" :class="{ 'selected': selectedTabKey === item.key }">{{ item.label }}</p>
+        <div v-if="selectedTabKey === item.key" class="line"></div>
+      </div>
+    </div>
+    <div class="panel-list">
+      <div class="panel-item" v-if="selectedTabKey === 'find'">
+        <SearchInput/>
+      </div>
+      <div class="panel-item" v-if="selectedTabKey === 'replace'">
+        <div class="line-item">
+          <span class="line-title">查找</span>
+          <SearchInput/>
+        </div>
+        <div class="line-item">
+          <span class="line-title">替换为</span>
+          <Input v-model:value="searchObj.replaceText" placeholder="输入替换内容"/>
+        </div>
+        <div class="line-item line-item-btn">
+          <Button @click="replace()">替换</Button>
+          <Button type="primary" @click="replaceAll()">全部替换</Button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref } from 'vue'
+import { storeToRefs } from 'pinia'
+import useSearch from '@/hooks/useSearch'
+import { useMainStore } from '@/store'
+import SearchInput from './SearchInput.vue'
+import { Input, Button } from 'ant-design-vue'
+
+const tabList = [
+  {
+    key: 'find',
+    label: '查找',
+  },
+  {
+    key: 'replace',
+    label: '替换',
+  },
+]
+
+export default defineComponent({
+  name: 'search-panel',
+  emits: ['select'],
+  components: {
+    SearchInput,
+    Input,
+    Button,
+  },
+  setup(props, { emit }) {
+    const selectedTabKey = ref(tabList[0].key)
+    const { searchObj } = storeToRefs(useMainStore())
+    const { replace, replaceAll } = useSearch()
+
+    return {
+      tabList,
+      selectedTabKey,
+      searchObj,
+      replace,
+      replaceAll,
+    }
+  },
+})
+</script>
+
+<style lang="scss" scoped>
+.search-panel {
+  box-sizing: border-box;
+  width: 281px;
+  display: flex;
+  flex-direction: column;
+
+  .tabs {
+    display: flex;
+    align-items: center;
+    border-bottom: 1px solid $borderColor;
+    margin-left: 8px;
+  }
+  .tab {
+    position: relative;
+    border-bottom: 2px solid transparent;
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    margin-right: 16px;
+    .text {
+      padding-bottom: 4px;
+      font-weight: 500;
+    }
+    .selected {
+      color: $themeColor;
+    }
+    .line {
+      position: absolute;
+      box-sizing: border-box;
+      bottom: 0;
+      width: 60%;
+      height: 2px;
+      background-color: $themeColor;
+    }
+  }
+  .panel-list {
+    box-sizing: border-box;
+    padding: 16px 20px 0px 20px;
+    margin: 0 -12px;
+    flex: 1;
+    font-size: 14px;
+    @include overflow-overlay();
+    @include flex-grid-layout();
+  }
+  .panel-item {
+    width: 100%;
+  }
+  .line-item {
+    display: flex;
+    margin-bottom: 12px;
+    justify-content: space-between;
+    .line-title {
+      line-height: 32px;
+      font-size: 13px;
+    }
+    .search-input,.ant-input {
+      width: 210px;
+    }
+  }
+  .line-item-btn {
+    justify-content: end;
+  }
+  .ant-btn {
+    width: 63px;
+    height: 28px;
+    border-color: #22AB82;
+    border-radius: 6px;
+    padding: 0px;
+    font-size: 12px;
+    line-height: 12px;
+    font-weight: 400;
+  }
+  .ant-btn:hover {
+    color: #41464b;
+  }
+  .ant-btn-primary {
+    background: #22AB82;
+    margin-left: 12px;
+  }
+  .ant-btn-primary:hover {
+    color: #fff;
+  }
+}
+</style>

--- a/src/views/Editor/CanvasTool/SearchPanel.vue
+++ b/src/views/Editor/CanvasTool/SearchPanel.vue
@@ -144,8 +144,7 @@ export default defineComponent({
   .ant-btn {
     width: 63px;
     height: 28px;
-    border-color: #22AB82;
-    border-radius: 6px;
+    border-radius: 4px;
     padding: 0px;
     font-size: 12px;
     line-height: 12px;
@@ -155,7 +154,6 @@ export default defineComponent({
     color: #41464b;
   }
   .ant-btn-primary {
-    background: #22AB82;
     margin-left: 12px;
   }
   .ant-btn-primary:hover {

--- a/src/views/Editor/CanvasTool/index.vue
+++ b/src/views/Editor/CanvasTool/index.vue
@@ -78,6 +78,14 @@
           <IconVideoTwo class="handler-item" />
         </Tooltip>
       </Popover>
+      <Popover trigger="click" v-model:visible="searchPanelVisible">
+        <template #content>
+            <SearchPanel/>
+        </template>
+        <Tooltip :mouseLeaveDelay="0" :mouseEnterDelay="0.5" title="查找/替换">
+          <IconSearch class="handler-item" />
+        </Tooltip>
+      </Popover>
     </div>
 
     <div class="right-handler">
@@ -117,7 +125,7 @@
 </template>
 
 <script lang="ts" setup>
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useMainStore, useSnapshotStore } from '@/store'
 import { getImageDataURL } from '@/utils/image'
@@ -126,12 +134,14 @@ import { LinePoolItem } from '@/configs/lines'
 import useScaleCanvas from '@/hooks/useScaleCanvas'
 import useHistorySnapshot from '@/hooks/useHistorySnapshot'
 import useCreateElement from '@/hooks/useCreateElement'
+import useSearch from '@/hooks/useSearch'
 
 import ShapePool from './ShapePool.vue'
 import LinePool from './LinePool.vue'
 import ChartPool from './ChartPool.vue'
 import TableGenerator from './TableGenerator.vue'
 import MediaInput from './MediaInput.vue'
+import SearchPanel from './SearchPanel.vue'
 import LaTeXEditor from '@/components/LaTeXEditor/index.vue'
 import FileInput from '@/components/FileInput.vue'
 import {
@@ -183,6 +193,7 @@ const tableGeneratorVisible = ref(false)
 const mediaInputVisible = ref(false)
 const latexEditorVisible = ref(false)
 const textTypeSelectVisible = ref(false)
+const searchPanelVisible = ref(false)
 
 // 绘制文字范围
 const drawText = (vertical = false) => {
@@ -209,6 +220,13 @@ const drawLine = (line: LinePoolItem) => {
   })
   linePoolVisible.value = false
 }
+
+// 查找替换
+const { cancelSearch } = useSearch()
+watch(searchPanelVisible, val => {
+  !val && cancelSearch()
+})
+
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
增加搜索/替换功能
1. 搜索，搜索框内输入暂停或回车触发搜索，搜索到内容后自动定位到slide并高亮内容，支持上/下按钮或连续回车定位到上/下一个出现位置，不支持块内容跨节点情况（如搜索"ab"，其中a是粗体，b是斜体，分布在两个span中）
2. 替换，基于搜索到的内容进行替换，替换当前搜索到内容后自动定位到下一个可替换位置
<img width="351" alt="image" src="https://github.com/pipipi-pikachu/PPTist/assets/5433378/4a093bfb-6bd2-44b4-b748-6637f6343f2d">