### PR TITLE
fix: export pptx fail when element width 0

### DIFF
--- a/src/components/NumberInput.vue
+++ b/src/components/NumberInput.vue
@@ -22,10 +22,10 @@
         @keydown.enter="$event => emit('enter', $event)"
       />
       <div class="handlers">
-        <span class="handler" @click="number += step">
+        <span class="handler" @click="add(step)">
           <svg fill="currentColor" width="1em" height="1em" viewBox="64 64 896 896"><path d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"></path></svg>
         </span>
-        <span class="handler" @click="number -= step">
+        <span class="handler" @click="add(-step)">
           <svg fill="currentColor" width="1em" height="1em" viewBox="64 64 896 896"><path d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"></path></svg>
         </span>
       </div>
@@ -65,9 +65,10 @@ const emit = defineEmits<{
 
 const number = ref(0)
 const focused = ref(false)
+let tmp_value = 0
 
 watch(() => props.value, () => {
-  if (props.value !== number.value) {
+  if (props.value !== tmp_value) {
     number.value = props.value
   }
 }, {
@@ -75,17 +76,26 @@ watch(() => props.value, () => {
 })
 
 watch(number, () => {
-  let value = +number.value
-  if (isNaN(value)) value = props.min
-  else if (value > props.max) value = props.max
-  else if (value < props.min) value = props.min
+  tmp_value = +number.value
+  if (isNaN(tmp_value)) tmp_value = props.min
+  else if (tmp_value > props.max) tmp_value = props.max
+  else if (tmp_value < props.min) tmp_value = props.min
 
-  number.value = value
-  emit('update:value', number.value)
+  emit('update:value', tmp_value)
 })
+
+const add = (value: number) => {
+  tmp_value = +number.value + value
+  if (isNaN(tmp_value)) tmp_value = props.min
+  else if (tmp_value > props.max) tmp_value = props.max
+  else if (tmp_value < props.min) tmp_value = props.min
+
+  number.value = tmp_value
+}
 
 const handleBlur = (e: Event) => {
   focused.value = false
+  number.value = tmp_value
   emit('blur', e)
 }
 const handleFocus = (e: Event) => {

--- a/src/hooks/useExport.ts
+++ b/src/hooks/useExport.ts
@@ -440,6 +440,10 @@ export default () => {
           if (el.opacity !== undefined) options.transparency = (1 - el.opacity) * 100
           if (el.paragraphSpace !== undefined) options.paraSpaceBefore = el.paragraphSpace * PT_PX_RATIO
           if (el.vertical) options.vert = 'eaVert'
+          if (el.glow) {
+            const c = formatColor(el.glow.color || '#ffffff')
+            options.glow = { color: c.color, opacity: c.alpha, size: (el.glow.size || 0) * PT_PX_RATIO }
+          }
 
           pptxSlide.addText(textProps, options)
         }

--- a/src/hooks/useExport.ts
+++ b/src/hooks/useExport.ts
@@ -490,6 +490,7 @@ export default () => {
         else if (el.type === 'shape') {
           if (el.special) {
             const svgRef = document.querySelector(`.thumbnail-list .base-element-${el.id} svg`) as HTMLElement
+            if (svgRef.clientWidth * svgRef.clientHeight < 1) continue
             const base64SVG = svg2Base64(svgRef)
 
             const options: pptxgen.ImageProps = {
@@ -740,6 +741,7 @@ export default () => {
         
         else if (el.type === 'latex') {
           const svgRef = document.querySelector(`.thumbnail-list .base-element-${el.id} svg`) as HTMLElement
+          if (svgRef.clientWidth * svgRef.clientHeight < 1) continue
           const base64SVG = svg2Base64(svgRef)
 
           const options: pptxgen.ImageProps = {

--- a/src/mocks/theme.ts
+++ b/src/mocks/theme.ts
@@ -11,6 +11,11 @@ export const theme: SlideTheme = {
     blur: 2,
     color: '#808080',
   },
+  glow: {
+    size: 0,
+    opacity: 1,
+    color: '#ffffff',
+  },
   outline: {
     width: 2,
     color: '#525252',

--- a/src/types/slides.ts
+++ b/src/types/slides.ts
@@ -53,6 +53,21 @@ export interface PPTElementShadow {
 }
 
 /**
+ * 文字发光
+ * 
+ * size?: 发光大小
+ * 
+ * opacity?: 发光透明度
+ * 
+ * color?: 发光颜色
+ */
+export interface PPTElementGlow {
+  size?: number
+  opacity?: number
+  color?: string
+}
+
+/**
  * 元素边框
  * 
  * style?: 边框样式（实线或虚线）
@@ -149,6 +164,7 @@ export interface PPTTextElement extends PPTBaseElement {
   content: string
   defaultFontName: string
   defaultColor: string
+  glow?: PPTElementGlow
   outline?: PPTElementOutline
   fill?: string
   lineHeight?: number
@@ -715,6 +731,7 @@ export interface SlideTheme {
   themeColor: string
   fontColor: string
   fontName: string
+  glow: PPTElementGlow
   outline: PPTElementOutline
   shadow: PPTElementShadow
 }

--- a/src/utils/prosemirror/schema/marks.ts
+++ b/src/utils/prosemirror/schema/marks.ts
@@ -132,7 +132,7 @@ const fontname: MarkSpec = {
   toDOM: mark => {
     const { fontname } = mark.attrs
     let style = ''
-    if (fontname) style += `font-family: ${fontname};`
+    if (fontname) style += `font-family: "${fontname}";`
     return ['span', { style }, 0]
   },
 }

--- a/src/views/Editor/Toolbar/ElementPositionPanel.vue
+++ b/src/views/Editor/Toolbar/ElementPositionPanel.vue
@@ -134,7 +134,7 @@ const top = ref(0)
 const width = ref(0)
 const height = ref(0)
 const rotate = ref(0)
-const fixedRatio = ref(false)
+const fixedRatio = ref(0)
 
 const minSize = computed(() => {
   if (!handleElement.value) return 20
@@ -154,7 +154,14 @@ watch(handleElement, () => {
   left.value = round(handleElement.value.left, 1)
   top.value = round(handleElement.value.top, 1)
 
-  fixedRatio.value = 'fixedRatio' in handleElement.value && !!handleElement.value.fixedRatio
+  if ('fixedRatio' in handleElement.value && !!handleElement.value.fixedRatio) {
+    if (Math.abs(fixedRatio.value) < 1e-9) {
+      fixedRatio.value = handleElement.value.width / handleElement.value.height
+    } 
+  }
+  else {
+    fixedRatio.value = 0
+  }
 
   if (handleElement.value.type !== 'line') {
     width.value = round(handleElement.value.width, 1)
@@ -198,7 +205,7 @@ const updateShapePathData = (width: number, height: number) => {
   return null
 }
 const updateWidth = (value: number) => {
-  let props = { width: value }
+  let props = fixedRatio.value ? {width: value, height: value / fixedRatio.value} : { width: value }
   const shapePathData = updateShapePathData(value, height.value)
   if (shapePathData) props = { ...props, ...shapePathData }
 
@@ -206,7 +213,7 @@ const updateWidth = (value: number) => {
   addHistorySnapshot()
 }
 const updateHeight = (value: number) => {
-  let props = { height: value }
+  let props = fixedRatio.value ? {width: value * fixedRatio.value, height: value} : {height: value}
   const shapePathData = updateShapePathData(width.value, value)
   if (shapePathData) props = { ...props, ...shapePathData }
 

--- a/src/views/Editor/Toolbar/ElementPositionPanel.vue
+++ b/src/views/Editor/Toolbar/ElementPositionPanel.vue
@@ -205,6 +205,7 @@ const updateShapePathData = (width: number, height: number) => {
   return null
 }
 const updateWidth = (value: number) => {
+  if (value === width.value) return
   let props = fixedRatio.value ? {width: value, height: value / fixedRatio.value} : { width: value }
   const shapePathData = updateShapePathData(value, height.value)
   if (shapePathData) props = { ...props, ...shapePathData }
@@ -213,6 +214,7 @@ const updateWidth = (value: number) => {
   addHistorySnapshot()
 }
 const updateHeight = (value: number) => {
+  if (value === height.value) return
   let props = fixedRatio.value ? {width: value * fixedRatio.value, height: value} : {height: value}
   const shapePathData = updateShapePathData(width.value, value)
   if (shapePathData) props = { ...props, ...shapePathData }

--- a/src/views/Editor/Toolbar/ElementStylePanel/TableStylePanel.vue
+++ b/src/views/Editor/Toolbar/ElementStylePanel/TableStylePanel.vue
@@ -93,6 +93,10 @@
 
     <Divider />
 
+    <ElementGlow :fixed="true" />
+
+    <Divider />
+
     <ElementOutline :fixed="true" />
 
     <Divider />
@@ -176,6 +180,7 @@ import type { PPTTableElement, TableCell, TableCellStyle, TableTheme } from '@/t
 import { WEB_FONTS } from '@/configs/font'
 import useHistorySnapshot from '@/hooks/useHistorySnapshot'
 
+import ElementGlow from '../common/ElementGlow.vue'
 import ElementOutline from '../common/ElementOutline.vue'
 import ColorButton from '../common/ColorButton.vue'
 import TextColorButton from '../common/TextColorButton.vue'

--- a/src/views/Editor/Toolbar/ElementStylePanel/TextStylePanel.vue
+++ b/src/views/Editor/Toolbar/ElementStylePanel/TextStylePanel.vue
@@ -313,6 +313,8 @@
     </div>
 
     <Divider />
+    <ElementGlow />
+    <Divider />
     <ElementOutline />
     <Divider />
     <ElementShadow />
@@ -333,6 +335,7 @@ import useTextFormatPainter from '@/hooks/useTextFormatPainter'
 import message from '@/utils/message'
 
 import ElementOpacity from '../common/ElementOpacity.vue'
+import ElementGlow from '../common/ElementGlow.vue'
 import ElementOutline from '../common/ElementOutline.vue'
 import ElementShadow from '../common/ElementShadow.vue'
 import ColorButton from '../common/ColorButton.vue'

--- a/src/views/Editor/Toolbar/common/ElementGlow.vue
+++ b/src/views/Editor/Toolbar/common/ElementGlow.vue
@@ -1,0 +1,103 @@
+<template>
+  <div class="element-glow">
+    <div class="row" v-if="!fixed">
+      <div style="width: 40%;">文字发光：</div>
+      <div class="switch-wrapper" style="width: 60%;">
+        <Switch 
+          :value="hasGlow" 
+          @update:value="value => toggleGlow(value)" 
+        />
+      </div>
+    </div>
+    <template v-if="hasGlow && glow">
+      <div class="row">
+        <div style="width: 40%;">发光颜色：</div>
+        <Popover trigger="click" style="width: 60%;">
+          <template #content>
+            <ColorPicker
+              :modelValue="glow.color"
+              @update:modelValue="value => updateGlow({ color: value })"
+            />
+          </template>
+          <ColorButton :color="glow.color || '#000'" />
+        </Popover>
+      </div>
+      <div class="row">
+        <div style="width: 40%;">发光大小：</div>
+        <NumberInput 
+          :value="glow.size || 0" 
+          @update:value="value => updateGlow({ size: value })" 
+          style="width: 60%;" 
+        />
+      </div>
+    </template>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref, watch } from 'vue'
+import { storeToRefs } from 'pinia'
+import { useMainStore, useSlidesStore } from '@/store'
+import type { PPTElementGlow } from '@/types/slides'
+import useHistorySnapshot from '@/hooks/useHistorySnapshot'
+
+import ColorButton from './ColorButton.vue'
+import ColorPicker from '@/components/ColorPicker/index.vue'
+import Switch from '@/components/Switch.vue'
+import NumberInput from '@/components/NumberInput.vue'
+import Select from '@/components/Select.vue'
+import Popover from '@/components/Popover.vue'
+
+withDefaults(defineProps<{
+  fixed?: boolean
+}>(), {
+  fixed: false,
+})
+
+const slidesStore = useSlidesStore()
+const { theme } = storeToRefs(slidesStore)
+const { handleElement } = storeToRefs(useMainStore())
+
+const glow = ref<PPTElementGlow>()
+const hasGlow = ref(false)
+
+watch(handleElement, () => {
+  if (!handleElement.value) return
+  glow.value = 'glow' in handleElement.value ? handleElement.value.glow : undefined
+  hasGlow.value = !!glow.value
+}, { deep: true, immediate: true })
+
+const { addHistorySnapshot } = useHistorySnapshot()
+
+const updateGlow = (glowProps: Partial<PPTElementGlow>) => {
+  if (!handleElement.value) return
+  const props = { glow: { ...glow.value, ...glowProps } }
+  slidesStore.updateElement({ id: handleElement.value.id, props })
+  addHistorySnapshot()
+}
+
+const toggleGlow = (checked: boolean) => {
+  if (!handleElement.value) return
+  if (checked) {
+    const _glow: PPTElementGlow = theme.value.glow
+    slidesStore.updateElement({ id: handleElement.value.id, props: { glow: _glow } })
+  }
+  else {
+    slidesStore.removeElementProps({ id: handleElement.value.id, propName: 'glow' })
+  }
+  addHistorySnapshot()
+}
+</script>
+
+<style lang="scss" scoped>
+.row {
+  width: 100%;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  margin-bottom: 10px;
+}
+.switch-wrapper {
+  text-align: right;
+}
+</style>

--- a/src/views/components/element/TextElement/BaseTextElement.vue
+++ b/src/views/components/element/TextElement/BaseTextElement.vue
@@ -49,14 +49,15 @@ import { computed } from 'vue'
 import type { PPTTextElement } from '@/types/slides'
 import ElementOutline from '@/views/components/element/ElementOutline.vue'
 
-import useElementShadow from '@/views/components/element/hooks/useElementShadow'
+import useElementShadowGlow from '@/views/components/element/hooks/useElementShadowGlow'
 
 const props = defineProps<{
   elementInfo: PPTTextElement
 }>()
 
 const shadow = computed(() => props.elementInfo.shadow)
-const { shadowStyle } = useElementShadow(shadow)
+const glow = computed(() => props.elementInfo.glow)
+const { shadowStyle } = useElementShadowGlow(shadow, glow)
 </script>
 
 <style lang="scss" scoped>

--- a/src/views/components/element/TextElement/index.vue
+++ b/src/views/components/element/TextElement/index.vue
@@ -66,7 +66,7 @@ import { debounce } from 'lodash'
 import { useMainStore, useSlidesStore } from '@/store'
 import type { PPTTextElement } from '@/types/slides'
 import type { ContextmenuItem } from '@/components/Contextmenu/types'
-import useElementShadow from '@/views/components/element/hooks/useElementShadow'
+import useElementShadowGlow from '@/views/components/element/hooks/useElementShadowGlow'
 import useHistorySnapshot from '@/hooks/useHistorySnapshot'
 
 import ElementOutline from '@/views/components/element/ElementOutline.vue'
@@ -87,7 +87,8 @@ const { addHistorySnapshot } = useHistorySnapshot()
 const elementRef = ref<HTMLElement>()
 
 const shadow = computed(() => props.elementInfo.shadow)
-const { shadowStyle } = useElementShadow(shadow)
+const glow = computed(() => props.elementInfo.glow)
+const { shadowStyle } = useElementShadowGlow(shadow, glow)
 
 const handleSelectElement = (e: MouseEvent | TouchEvent, canMove = true) => {
   if (props.elementInfo.lock) return

--- a/src/views/components/element/hooks/useElementShadowGlow.ts
+++ b/src/views/components/element/hooks/useElementShadowGlow.ts
@@ -1,0 +1,30 @@
+import { computed, type Ref } from 'vue'
+import type { PPTElementGlow, PPTElementShadow } from '@/types/slides'
+
+// 计算元素的阴影样式
+export default (shadow: Ref<PPTElementShadow | undefined>, glow: Ref<PPTElementGlow|undefined>) => {
+  const shadowStyle = computed(() => {
+    const s = []
+    if (shadow.value) {
+      const { h, v, blur, color } = shadow.value
+      s.push( `${h}px ${v}px ${blur}px ${color}`)
+    }
+    if (glow.value) {
+      const { size, color } = glow.value
+      const n = Math.max(Math.ceil((size || 0) / 3) - 2, 1)
+      const m = Math.floor(n / 2)
+      const blur = Math.min(((size || 0) / 3), 3)
+      for (let x = 0; x <= n; x++) {
+        for (let y = 0; y <= n; y++) {
+          s.push(`${x - m}px ${y - m}px ${blur}px ${color}`)
+        }
+      }
+
+    }
+    return s.join(', ')
+  })
+
+  return {
+    shadowStyle,
+  }
+}


### PR DESCRIPTION
如果不小心编辑出 0 宽度的元素，会导致无法导出pptx。示例pptist文件 
[未命名演示文稿.zip](https://github.com/pipipi-pikachu/PPTist/files/14520505/default.zip)

![image](https://github.com/pipipi-pikachu/PPTist/assets/5772409/a75c92ab-2b00-453d-a911-47be9018e0f3)
