### PR TITLE
Improve CustomElement.md

### DIFF
--- a/doc/CustomElement.md
+++ b/doc/CustomElement.md
@@ -222,8 +222,8 @@ const handleSelectElement = (e: MouseEvent | TouchEvent, canMove = true) => {
 </template>
 
 <script lang="ts" setup>
-import { PropType } from 'vue'
-import { PPTFrameElement } from '@/types/slides'
+import type { PropType } from 'vue'
+import type { PPTFrameElement } from '@/types/slides'
 
 const props = defineProps({
   elementInfo: {
@@ -345,10 +345,15 @@ const updateURL = () => {
 }
 </script>
 ```
+
+
+
 ```html
+<!-- src\views\Editor\Toolbar\ElementStylePanel\index.vue -->
+
 <script lang="ts" setup>
 import FrameStylePanel from './FrameStylePanel.vue'
-  
+
 const panelMap = {
   [ElementTypes.TEXT]: TextStylePanel,
   [ElementTypes.IMAGE]: ImageStylePanel,


### PR DESCRIPTION
```
import { PropType } from 'vue'
import { PPTFrameElement } from '@/types/slides'
```

按照 CustomElement.md 中示例代码会收到这样的错误信息：

```
"source": "ts-plugin"

"'PropType' is a type and must be imported using a type-only import when 'verbatimModuleSyntax' is enabled."

"'PPTFrameElement' is a type and must be imported using a type-only import when 'verbatimModuleSyntax' is enabled."
```



为了避免新手懵掉，所以更新一下教程内容。

```diff
- import { PropType } from 'vue'
- import { PPTFrameElement } from '@/types/slides'

+ import type { PropType } from 'vue'
+ import type { PPTFrameElement } from '@/types/slides'
```
