### PR TITLE
fix(export): 修复图片引发的导出问题

### DIFF
--- a/src/configs/common.ts
+++ b/src/configs/common.ts
@@ -1,0 +1,2 @@
+// 是否允许导出跨域资源
+export const allowCorsWhenExport = true

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -22,3 +22,19 @@ export const isPC = () => {
 export const isValidURL = (url: string) => {
   return /^(https?:\/\/)([\w-]+\.)+[\w-]{2,}(\/[\w-./?%&=]*)?$/i.test(url)
 }
+
+/**
+ * 判断是否为跨域资源
+ * @param resourceUrl
+ */
+export const isCrossOriginResource = (resourceUrl: string): boolean => {
+  try {
+    // 相对路径配置当前域名作为基础路径
+    const resourceOrigin = new URL(resourceUrl, window.location.href).origin
+    const currentOrigin = window.location.origin
+    return resourceOrigin !== currentOrigin
+  }
+  catch (error) {
+    return true // 出于安全考虑，如果 URL 无效，将其视为跨域
+  }
+}

--- a/src/utils/imgPath2Base64Png.ts
+++ b/src/utils/imgPath2Base64Png.ts
@@ -1,0 +1,41 @@
+/**
+ * 通过canvas将外部链接图片转换为base64 png, 报错时返回空字符串
+ * @param url
+ */
+export const urlImgToBase64 = (url: string): Promise<string> => {
+  return new Promise((resolve) => {
+    if (url.startsWith('data:image/')) {
+      resolve(url)
+    }
+    else {
+      try {
+        // 新开一个OffscreenCanvas处理，避免阻塞主线程
+        const canvas: OffscreenCanvas = new OffscreenCanvas(512, 512)// 创建一个离屏 Canvas
+        const ctx = canvas.getContext('2d')
+
+        const img = new Image()
+        img.crossOrigin = 'anonymous'
+        img.onload = function() {
+          canvas.width = img.width
+          canvas.height = img.height
+                    ctx!.drawImage(img, 0, 0)
+                    // 将 Canvas 转换为 base64
+                    canvas.convertToBlob({type: 'image/png'}).then((blob: Blob) => {
+                      const reader = new FileReader()
+                      reader.onloadend = () => {
+                        resolve(reader.result as string)
+                      }
+                      reader.readAsDataURL(blob)
+                    })
+        }
+        img.onerror = function() {
+          resolve('')
+        }
+        img.src = url
+      }
+      catch (e) {
+        resolve('')
+      }
+    }
+  })
+}


### PR DESCRIPTION
修复以下两个图片导出问题：

1. 图片 src 为空时导致导出图片错误，目前导出前进行过滤，导出时对应图片为空 符合预期(后续发现图片资源加载报错时也会出现此错误，但查看文档后没找到忽略的选项，导出前进行加载尝试感觉代价又较大)。
2. 跨域资源图片导致导出pptx文件无法打开，现在会将跨域图片转换为 Base64。

背景：
在使用 AI 生成 PPT 项目时，由于生成的数据不稳定，出现了以上问题。进行了特殊数据/普通数据及混合情况的测试，未发现额外带来的问题。pptx生成问题上与pptgenjs后续查到的作者推荐思路相同，但官方应该不会主动修改，参考issue
https://github.com/gitbrent/PptxGenJS/issues/318。
看到这是个很好的开源项目，希望做出一些贡献，第一次提交pr，可能有些不合适的地方，如有问题，我会尽量积极响应。

![pptxError](https://github.com/user-attachments/assets/37e48181-0db4-4012-a4d9-686d194c7991)