### PR TITLE
fix: 跨域请求导致的无法完成初始化

### DIFF
--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,7 +1,6 @@
 import axios from './config'
 
 export const SERVER_URL = (import.meta.env.MODE === 'development') ? '/api' : 'https://server.pptist.cn'
-export const ASSET_URL = 'https://asset.pptist.cn'
 
 export default {
   getMockData(filename: string): Promise<any> {
@@ -9,7 +8,7 @@ export default {
   },
 
   getFileData(filename: string): Promise<any> {
-    return axios.get(`${ASSET_URL}/data/${filename}.json`)
+    return axios.get(`./mocks/${filename}.json`)
   },
 
   AIPPT_Outline(content: string, language: string): Promise<any> {


### PR DESCRIPTION
我在用WebStorm启动该项目时出现了https://github.com/pipipi-pikachu/PPTist/issues/301  里问题【2】同样的现象，且无法通过127.0.0.1访问

好奇为什么本地存了一份还要请求asset.pptist.cn ?
修改为调用本地的文件夹  ./mocks