### PR TITLE
fix: 提取 font-size 支持小数

### DIFF
--- a/src/hooks/useAIPPT.ts
+++ b/src/hooks/useAIPPT.ts
@@ -102,7 +102,7 @@ export default () => {
   }
   
   const getFontInfo = (htmlString: string) => {
-    const fontSizeRegex = /font-size:\s*(\d+)\s*px/i
+    const fontSizeRegex = /font-size:\s*(\d+(?:\.\d{1,2})?)\s*px/i
     const fontFamilyRegex = /font-family:\s*['"]?([^'";]+)['"]?\s*(?=;|>|$)/i
   
     const defaultInfo = {


### PR DESCRIPTION
之前只支持 font-size: 16 px;
现在可以支持 font-size: 16.67 px; 这种两位小数

另外还有一个疑问，项目是否考虑添加部分自动化测试，我这边可以提供一些 setup.