### PR TITLE
feat: 优化略图栏展示，只展示视线范围内

### DIFF
--- a/src/hooks/useThumbnailVisibleScope.ts
+++ b/src/hooks/useThumbnailVisibleScope.ts
@@ -1,0 +1,39 @@
+import { computed, ref } from 'vue'
+import { storeToRefs } from 'pinia'
+import { useSlidesStore } from '@/store'
+import { debounce } from 'lodash'
+
+export default () => {
+  const { slides } = storeToRefs(useSlidesStore())
+
+  /* 略图栏展示范围 */
+  const slidesVisibleScope = ref<number[]>([0, 30])
+
+  const setThumbnailVisibleScope = (newScope:number[]) => {
+    slidesVisibleScope.value = newScope
+  }
+
+  /* 左侧略图展示 */
+  const thumbnailVisible = computed(() => (index: number) => {
+    if (slides.value.length <= 30) {
+      return true
+    }
+    return index >= slidesVisibleScope.value[0] && index < slidesVisibleScope.value[1]
+  })
+
+  /* 监听thumbnails滚动 获取视线范围 */
+  const listenThumbnailsScroll = debounce(function() {
+    const thumbnailEl = document.querySelector('.thumbnail-list')
+    const scrollTop = thumbnailEl?.scrollTop || 0
+    const itemHeight = thumbnailEl?.clientHeight || 0
+
+    // 计算获取视线里的
+    let _sight = Math.floor((scrollTop + itemHeight) / 77.5)
+    if (_sight < 30) _sight = 30
+    setThumbnailVisibleScope([_sight - 30, _sight + 20])
+  }, 100)
+  return {
+    thumbnailVisible,
+    listenThumbnailsScroll
+  }
+}

--- a/src/views/Editor/Thumbnails/index.vue
+++ b/src/views/Editor/Thumbnails/index.vue
@@ -25,6 +25,7 @@
       :disabled="editingSectionId"
       @end="handleDragEnd"
       itemKey="id"
+      @scroll="listenThumbnailsScroll"
     >
       <template #item="{ element, index }">
         <div class="thumbnail-container">
@@ -57,7 +58,7 @@
             v-contextmenu="contextmenusThumbnailItem"
           >
             <div class="label" :class="{ 'offset-left': index >= 99 }">{{ fillDigit(index + 1, 2) }}</div>
-            <ThumbnailSlide class="thumbnail" :slide="element" :size="120" :visible="index < slidesLoadLimit" />
+            <ThumbnailSlide class="thumbnail" :slide="element" :size="120" :visible="thumbnailVisible(index)" />
   
             <div class="note-flag" v-if="element.notes && element.notes.length" @click="openNotesPanel()">{{ element.notes.length }}</div>
           </div>
@@ -79,7 +80,8 @@ import type { ContextmenuItem } from '@/components/Contextmenu/types'
 import useSlideHandler from '@/hooks/useSlideHandler'
 import useSectionHandler from '@/hooks/useSectionHandler'
 import useScreening from '@/hooks/useScreening'
-import useLoadSlides from '@/hooks/useLoadSlides'
+// import useLoadSlides from '@/hooks/useLoadSlides'
+import useThumbnailVisibleScope from '@/hooks/useThumbnailVisibleScope'
 
 import ThumbnailSlide from '@/views/components/ThumbnailSlide/index.vue'
 import Templates from './Templates.vue'
@@ -93,7 +95,8 @@ const { selectedSlidesIndex: _selectedSlidesIndex, thumbnailsFocus } = storeToRe
 const { slides, slideIndex, currentSlide } = storeToRefs(slidesStore)
 const { ctrlKeyState, shiftKeyState } = storeToRefs(keyboardStore)
 
-const { slidesLoadLimit } = useLoadSlides()
+// const { slidesLoadLimit } = useLoadSlides()
+const { thumbnailVisible, listenThumbnailsScroll } = useThumbnailVisibleScope()
 
 const selectedSlidesIndex = computed(() => [..._selectedSlidesIndex.value, slideIndex.value])
 


### PR DESCRIPTION
ppt页面很多的时候，优化展示逻辑，只展示滚动到当前位置的上下范围内的略图栏