### PR TITLE
chore: update dexie v3.2.7 for fix high vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "axios": "^1.7.9",
         "clipboard": "^2.0.11",
         "crypto-js": "^4.2.0",
-        "dexie": "3.0.3",
+        "dexie": "3.2.7",
         "echarts": "^5.5.1",
         "file-saver": "^2.0.5",
         "hfmath": "^0.0.2",
@@ -2301,9 +2301,10 @@
       "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw=="
     },
     "node_modules/dexie": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmmirror.com/dexie/-/dexie-3.0.3.tgz",
-      "integrity": "sha512-BSFhGpngnCl1DOr+8YNwBDobRMH0ziJs2vts69VilwetHYOtEDcLqo7d/XiIphM0tJZ2rPPyAGd31lgH2Ln3nw==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dexie/-/dexie-3.2.7.tgz",
+      "integrity": "sha512-2a+BXvVhY5op+smDRLxeBAivE7YcYaneXJ1la3HOkUfX9zKkE/AJ8CNgjiXbtXepFyFmJNGSbmjOwqbT749r/w==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=6.0"
       }
@@ -6947,9 +6948,9 @@
       "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw=="
     },
     "dexie": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmmirror.com/dexie/-/dexie-3.0.3.tgz",
-      "integrity": "sha512-BSFhGpngnCl1DOr+8YNwBDobRMH0ziJs2vts69VilwetHYOtEDcLqo7d/XiIphM0tJZ2rPPyAGd31lgH2Ln3nw=="
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dexie/-/dexie-3.2.7.tgz",
+      "integrity": "sha512-2a+BXvVhY5op+smDRLxeBAivE7YcYaneXJ1la3HOkUfX9zKkE/AJ8CNgjiXbtXepFyFmJNGSbmjOwqbT749r/w=="
     },
     "dir-glob": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "axios": "^1.7.9",
     "clipboard": "^2.0.11",
     "crypto-js": "^4.2.0",
-    "dexie": "3.0.3",
+    "dexie": "3.2.7",
     "echarts": "^5.5.1",
     "file-saver": "^2.0.5",
     "hfmath": "^0.0.2",

--- a/src/store/snapshot.ts
+++ b/src/store/snapshot.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia'
 import type { IndexableTypeArray } from 'dexie'
+import { cloneDeep } from 'lodash'
 import { db, type Snapshot } from '@/utils/database'
 
 import { useSlidesStore } from './slides'
@@ -38,7 +39,7 @@ export const useSnapshotStore = defineStore('snapshot', {
   
       const newFirstSnapshot = {
         index: slidesStore.slideIndex,
-        slides: slidesStore.slides,
+        slides: cloneDeep(slidesStore.slides),
       }
       await db.snapshots.add(newFirstSnapshot)
       this.setSnapshotCursor(0)
@@ -63,7 +64,7 @@ export const useSnapshotStore = defineStore('snapshot', {
       // 添加新快照
       const snapshot = {
         index: slidesStore.slideIndex,
-        slides: slidesStore.slides,
+        slides: cloneDeep(slidesStore.slides),
       }
       await db.snapshots.add(snapshot)
   
@@ -83,7 +84,7 @@ export const useSnapshotStore = defineStore('snapshot', {
         db.snapshots.update(allKeys[snapshotLength - 2] as number, { index: slidesStore.slideIndex })
       }
   
-      await db.snapshots.bulkDelete(needDeleteKeys)
+      await db.snapshots.bulkDelete(needDeleteKeys as number[])
   
       this.setSnapshotCursor(snapshotLength - 1)
       this.setSnapshotLength(snapshotLength)


### PR DESCRIPTION
1. 升级以修复dexie版本高危安全漏洞
2. 升级后db.snapshots.add无法添加包含多层的proxy对象，改为通过cloneDeep复制全部原始值存入