### PR TITLE
fix: 修复导出 pptx 文件时 DOM 节点 style 属性解析问题

### DIFF
--- a/src/hooks/useExport.ts
+++ b/src/hooks/useExport.ts
@@ -171,7 +171,7 @@ export default () => {
         if (styleAttr && styleAttr.value) {
           const styleArr = styleAttr.value.split(';')
           for (const styleItem of styleArr) {
-            const [_key, _value] = styleItem.split(': ')
+            const [_key, _value] = styleItem.split(':')
             const [key, value] = [trim(_key), trim(_value)]
             if (key && value) styleObj[key] = value
           }


### PR DESCRIPTION
当前元素 style 属性的键和值按 `: ` 解析，将冒号后空格去掉更合适。

示例如下：导入以下 JSON 正常，导出文件后属性丢失。

<img width="1063" height="686" alt="image" src="https://github.com/user-attachments/assets/d1e42b4e-fa58-45b8-87b4-098b48fa5482" />

```json
{
  "title": "未命名演示文稿",
  "width": 1000,
  "height": 562.5,
  "theme": {
    "themeColors": [
      "#5b9bd5",
      "#ed7d31",
      "#a5a5a5",
      "#ffc000",
      "#4472c4",
      "#70ad47"
    ],
    "fontColor": "#333",
    "fontName": "",
    "backgroundColor": "#fff",
    "shadow": { "h": 3, "v": 3, "blur": 2, "color": "#808080" },
    "outline": { "width": 2, "color": "#525252", "style": "solid" }
  },
  "slides": [
    {
      "background": { "type": "solid", "color": "#ffffff" },
      "elements": [
        {
          "id": "78a1c97a-9b19-4b6e-8d02-0a2c4e3b1f9d",
          "type": "text",
          "left": 60,
          "top": 50,
          "width": 880,
          "height": 68,
          "content": "<p style=\"font-size:32px; text-align:center; font-weight:bold;\">test</p>",
          "defaultFontName": "SourceHanSans",
          "defaultColor": "#333333"
        },
        {
          "id": "2d1b7d5a-8b8f-4d3e-9b2f-9c1d0a5f8e01",
          "type": "text",
          "left": 60,
          "top": 150,
          "width": 880,
          "height": 68,
          "content": "<p style=\"font-size: 32px; text-align: center; font-weight: bold;\">test</p>",
          "defaultFontName": "SourceHanSans",
          "defaultColor": "#333333"
        }
      ]
    }
  ]
}
```

也可考虑用成熟的 CSS Parser 实现解析：

```js
import CSSOM from "cssom";

const parseStyleString = (styleString) => {
  const decl = CSSOM.parse(`*{${styleString}}`).cssRules[0].style;
  const result = {};

  for (let i = 0; i < decl.length; i++) {
    const key = decl[i];
    result[key] = decl.getPropertyValue(key);
  }
  return result;
};
```