### PR TITLE
fix: 优化音视频自动播放与入场/退场动画的交互

### DIFF
--- a/src/views/Screen/hooks/useExecPlay.ts
+++ b/src/views/Screen/hooks/useExecPlay.ts
@@ -5,7 +5,7 @@ import { useSlidesStore } from '@/store'
 import { KEYS } from '@/configs/hotkey'
 import { ANIMATION_CLASS_PREFIX } from '@/configs/animation'
 import message from '@/utils/message'
-import type { Slide } from '@/types/slides'
+import { ElementTypes, type Slide } from '@/types/slides'
 
 const AUDIENCE_SYNC_CHANNEL = 'pptist-audience-sync'
 
@@ -77,14 +77,17 @@ export default () => {
         continue
       }
 
+      // 退场动画执行时，关闭正在播放的音视频
+      if (animation.type === 'out') closePlayMedia(elRef)
+
       const animationName = `${ANIMATION_CLASS_PREFIX}${animation.effect}`
-      
+
       // 执行动画前先清除原有的动画状态（如果有）
       elRef.style.removeProperty('--animate-duration')
       for (const classname of elRef.classList) {
         if (classname.indexOf(ANIMATION_CLASS_PREFIX) !== -1) elRef.classList.remove(classname, `${ANIMATION_CLASS_PREFIX}animated`)
       }
-      
+
       // 执行动画
       elRef.style.setProperty('--animate-duration', `${animation.duration}ms`)
       elRef.classList.add(animationName, `${ANIMATION_CLASS_PREFIX}animated`)
@@ -95,6 +98,9 @@ export default () => {
           elRef.style.removeProperty('--animate-duration')
           elRef.classList.remove(animationName, `${ANIMATION_CLASS_PREFIX}animated`)
         }
+
+        // 入场动画结束后，播放设置了自动播放的音视频
+        if (animation.type === 'in' && isAutoPlayMedia(animation.elId)) playMedia(elRef)
 
         // 判断该位置上的全部动画都已经结束后，标记动画执行完成，并尝试继续向下执行（如果有需要）
         endAnimationCount += 1
@@ -140,7 +146,10 @@ export default () => {
     for (const animation of animations) {
       const elRef: HTMLElement | null = document.querySelector(`#screen-element-${animation.elId} [class^=base-element-]`)
       if (!elRef) continue
-      
+
+      // 撤回动画时，关闭正在播放的音视频
+      closePlayMedia(elRef)
+
       elRef.style.removeProperty('--animate-duration')
       for (const classname of elRef.classList) {
         if (classname.indexOf(ANIMATION_CLASS_PREFIX) !== -1) elRef.classList.remove(classname, `${ANIMATION_CLASS_PREFIX}animated`)
@@ -278,6 +287,34 @@ export default () => {
     if (!isAudienceMode) document.removeEventListener('keydown', keydownListener)
     syncChannel?.close()
   })
+
+  // 撤回动画 || 退场动画 关闭正在播放的音视频
+  const closePlayMedia = (el: HTMLElement | null) => {
+    if (!el) return
+    const audio = el.querySelector('audio')
+    if (audio) audio.pause()
+    const video = el.querySelector('video')
+    if (video) video.pause()
+  }
+
+  // 播放动画结束后需要自动播放的音视频
+  const playMedia = (el: HTMLElement | null) => {
+    if (!el) return
+    const audio = el.querySelector('audio')
+    if (audio) audio.play()
+    const video = el.querySelector('video')
+    if (video) video.play()
+  }
+
+  // 判断该元素是否为设置了自动播放的音视频
+  const isAutoPlayMedia = (elId: string) => {
+    const currentSlideEls = slides.value[slideIndex.value]?.elements || []
+    const el = currentSlideEls.find(item => item.id === elId)
+    if (!el) return false
+    if (el.type === ElementTypes.AUDIO) return el.autoplay
+    if (el.type === ElementTypes.VIDEO) return el.autoplay
+    return false
+  }
 
   // 切换到上一张/上一张幻灯片（无视元素的入场动画）
   const turnPrevSlide = () => {

--- a/src/views/components/element/AudioElement/AudioPlayer.vue
+++ b/src/views/components/element/AudioElement/AudioPlayer.vue
@@ -11,6 +11,7 @@
       @durationchange="handleDurationchange()"
       @timeupdate="handleTimeupdate()"
       @play="handlePlayed()"
+      @pause="paused = true"
       @ended="handleEnded()"
       @progress="handleProgress()"
       @error="handleError()"

--- a/src/views/components/element/AudioElement/ScreenAudioElement.vue
+++ b/src/views/components/element/AudioElement/ScreenAudioElement.vue
@@ -25,9 +25,9 @@
           ref="audioPlayerRef"
           v-if="inCurrentSlide"
           :style="{ ...audioPlayerPosition }"
-          :src="elementInfo.src" 
+          :src="elementInfo.src"
           :loop="elementInfo.loop"
-          :autoplay="elementInfo.autoplay"
+          :autoplay="elementInfo.autoplay && !hasEntranceAnimation"
           :scale="scale"
         />
       </div>
@@ -54,6 +54,17 @@ const scale = inject(injectKeySlideScale) || ref(1)
 const slideId = inject(injectKeySlideId) || ref('')
 
 const inCurrentSlide = computed(() => currentSlide.value.id === slideId.value)
+
+// 元素设置了“自动播放”且设有入场动画时，若元素仍处于入场动画前的隐藏状态则先不触发原生 autoplay；
+// 元素已可见（入场动画已执行完毕，如切回已播放页面）时则不再抑制，正常自动播放。
+const hasEntranceAnimation = computed(() => {
+  if (!currentSlide.value?.animations) return false
+  const hasInAnimation = currentSlide.value.animations.some(item => item.elId === props.elementInfo.id && item.type === 'in')
+  if (!hasInAnimation) return false
+  const el = document.querySelector(`#screen-element-${props.elementInfo.id}`)
+  if (el && getComputedStyle(el).visibility === 'visible') return false
+  return true
+})
 
 const audioIconSize = computed(() => {
   return Math.min(props.elementInfo.width, props.elementInfo.height) + 'px'

--- a/src/views/components/element/VideoElement/ScreenVideoElement.vue
+++ b/src/views/components/element/VideoElement/ScreenVideoElement.vue
@@ -16,10 +16,10 @@
           v-if="inCurrentSlide"
           :width="elementInfo.width"
           :height="elementInfo.height"
-          :src="elementInfo.src" 
-          :poster="elementInfo.poster"  
-          :autoplay="elementInfo.autoplay"
-          :scale="scale" 
+          :src="elementInfo.src"
+          :poster="elementInfo.poster"
+          :autoplay="elementInfo.autoplay && !hasEntranceAnimation"
+          :scale="scale"
         />
       </div>
     </div>
@@ -35,7 +35,7 @@ import { injectKeySlideId, injectKeySlideScale } from '@/types/injectKey'
 
 import VideoPlayer from './VideoPlayer/index.vue'
 
-defineProps<{
+const props = defineProps<{
   elementInfo: PPTVideoElement
 }>()
 
@@ -45,6 +45,17 @@ const scale = inject(injectKeySlideScale) || ref(1)
 const slideId = inject(injectKeySlideId) || ref('')
 
 const inCurrentSlide = computed(() => currentSlide.value.id === slideId.value)
+
+// 元素设置了“自动播放”且设有入场动画时，若元素仍处于入场动画前的隐藏状态则先不触发原生 autoplay；
+// 元素已可见（入场动画已执行完毕，如切回已播放页面）时则不再抑制，正常自动播放。
+const hasEntranceAnimation = computed(() => {
+  if (!currentSlide.value?.animations) return false
+  const hasInAnimation = currentSlide.value.animations.some(item => item.elId === props.elementInfo.id && item.type === 'in')
+  if (!hasInAnimation) return false
+  const el = document.querySelector(`#screen-element-${props.elementInfo.id}`)
+  if (el && getComputedStyle(el).visibility === 'visible') return false
+  return true
+})
 </script>
 
 <style lang="scss" scoped>

--- a/src/views/components/element/VideoElement/VideoPlayer/index.vue
+++ b/src/views/components/element/VideoElement/VideoPlayer/index.vue
@@ -28,7 +28,7 @@
         @ended="handleEnded()"
         @progress="handleProgress()"
         @play="autoHideController(); paused = false"
-        @pause="autoHideController()"
+        @pause="autoHideController(); paused = true"
         @error="handleError()"
       ></video>
       <div class="bezel">


### PR DESCRIPTION
1、修复了音视频元素、退场、撤回动画执行后，还在后台播放的问题；
2、优化了音视频元素设置了自动播放、入场动画的先后执行顺序，先执行完入场动画再自动播放；
3、修复2衍生的bug，页码切换时已经执行完动画的元素，应该会自动播放。